### PR TITLE
Typo fix

### DIFF
--- a/docs/docs/sourcing-from-the-filesystem.md
+++ b/docs/docs/sourcing-from-the-filesystem.md
@@ -69,7 +69,7 @@ The result is an array of File "nodes" (node is a fancy name for an object in a
 
 ## Transforming File nodes
 
-Once files have been sourced, various "transformer" plugins in the Gatsby ecosystem can then be used to transform File nodes into various other types of data. For example, a JSON file can be sourced using `gatsby-source-plugin`, and then the resulting File nodes can be transformed into JSON nodes using `gatsby-transformer-json`.
+Once files have been sourced, various "transformer" plugins in the Gatsby ecosystem can then be used to transform File nodes into various other types of data. For example, a JSON file can be sourced using `gatsby-source-filesystem` plugin, and then the resulting File nodes can be transformed into JSON nodes using `gatsby-transformer-json`.
 
 ## Further reference and examples
 


### PR DESCRIPTION
I'm new to gatsby, but there is no plugin named `gatsby-source-plugin`, so I assume it should be `gatsby-source-filesystem`
